### PR TITLE
MSVC needs _USE_MATH_DEFINES for cmath (CPP mode)

### DIFF
--- a/c_src_ref/floppsyhash.cpp
+++ b/c_src_ref/floppsyhash.cpp
@@ -1,3 +1,4 @@
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include "floppsyhash.h"
 


### PR DESCRIPTION
See https://ci.appveyor.com/project/rurban/smhasher/builds/30205199/job/gl6asig6v8kwm4us#L141
floppsyhash.cpp(25): error C2065: 'M_PI': undeclared identifier